### PR TITLE
Fix : Tree generation for vscode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
-  "name": "reactree",
-  "displayName": "ReacTree",
-  "description": "React hierarchy tree visualizer and navigation tool",
-  "version": "1.0.7",
+  "name": "reactreev2",
+  "displayName": "ReacTreeV2",
+  "description": "Fixed - React hierarchy tree visualizer and navigation tool",
+  "version": "2.0.0",
   "icon": "icon.png",
-  "publisher": "ReacTreeDev",
+  "publisher": "abhi11verma",
   "preview": false,
   "engines": {
     "vscode": "^1.74.3"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/oslabs-beta/ReacTree/tree/main"
+    "url": "https://github.com/abhi11verma/ReacTreeV2"
   },
   "categories": [
     "Other"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,10 +4,16 @@ import ReacTreePanel from './panel';
 export function activate(extContext: vscode.ExtensionContext) {
   extContext.subscriptions.push(
     vscode.commands.registerCommand('reacTree.start', () => {
-      ReacTreePanel.createOrShow(extContext);
+      const activeEditor = vscode.window.activeTextEditor;
+      if (activeEditor) {
+        const currentFilePath = activeEditor.document.uri.fsPath;
+        ReacTreePanel.createOrShow(extContext, currentFilePath);
+      } else {
+        vscode.window.showInformationMessage('No active editor found.');
+      }
     })
   );
-  
+
   // Create reacTree status bar button
   const item = vscode.window.createStatusBarItem(
     vscode.StatusBarAlignment.Right
@@ -15,7 +21,7 @@ export function activate(extContext: vscode.ExtensionContext) {
 
   item.command = 'reacTree.start';
   item.tooltip = 'Activate ReacTree';
-  item.text = '$(type-hierarchy) Start Tree';
+  item.text = '$(type-hierarchy) View Tree';
   item.show();
 }
 

--- a/src/webview/components/Navbar.tsx
+++ b/src/webview/components/Navbar.tsx
@@ -17,32 +17,33 @@ interface vscode {
 declare const vscode: vscode;
 
 const Navbar = ({ rootFile }: any) => {
-  // onChange function that will send a message to the extension when the user selects a file
-  const fileMessage = (e: any) => {
-    const filePath = e.target.files[0].path;
-    // Reset event target value to null so the same file selection causes onChange event to trigger
-    e.target.value = null;
-    if (filePath) {
-      vscode.postMessage({
-        type: "onFile",
-        value: filePath
-      });
-    }
-  };
+ // Listen for messages from the extension
+  React.useEffect(() => {
+    window.addEventListener('message', (event) => {
+      const message = event.data;
+      if (message.type === 'currentFilePath') {
+        sendFileMessage(message.value);
+      } else if (message.type === 'parsed-data') {
+        console.log('Restoring tree data:', message.value); // Add log
+      }
+    });
+  }, []);
 
+  // onChange function that will send a message to the extension when the user selects a file
+function sendFileMessage(filePath: string) {
+  vscode.postMessage({
+    type: 'onFile',
+    value: filePath,
+  });
+}
   console.log('ROOT', rootFile)
 
   // Render section
   return (
     <div className="navbar">
-      <input type="file" name="file" id="file" className="inputfile" onChange={(e) => {fileMessage(e);}}/>
       <div className='navbarContents'>
-        <label id='inputLabel' htmlFor="file">
-          {/* <FontAwesomeIcon icon={faDownload}/> */}
-          <strong id="strong_file">{rootFile ? ` ${rootFile}` : ' Select File'}</strong>
-          <FileUploadRoundedIcon htmlColor='var(--vscode-settings-focusedRowBorder)' style={{fontSize:20, position: 'relative', top: '4px'}}/>
-        </label>
-        {/* <ClearIcon style={{fontSize:15, marginTop: 2}}/>   */}
+        <label  className='navbarLabel' htmlFor="file-upload">
+          </label>
       </div>
     </div>
   );


### PR DESCRIPTION
<!---
☝️ Prefix your PR title with `fix:`, `feat:`, `docs:`, or other according to the Conventional Commits spec:
https://conventionalcommits.org

👉 Please make sure to follow the Contributing guidelines:
https://github.com/oslabs-beta/.github/blob/main/docs/CONTRIBUTING.md
-->

## Linked issue/ticket

<!-- GitHub Issue / Jira Ticket / Asana Ticket -->

## Description

Tree generation was failing after file selection,
This change modifies the way tree is generated instead of selecting the file, now the tree generation is done using the current open file.
Start Tree is now named as View Tree

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

## Reproduction steps

<!-- Include step-by-step instructions on how to reproduce and test this ticket. -->

## Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I've followed the [Contributing guidelines](https://github.com/oslabs-beta/.github/blob/main/docs/CONTRIBUTING.md)
- [x] I've titled my PR according to the [Conventional Commits spec](https://conventionalcommits.org)
- [ ] I've added tests that fail without this PR but pass with it
- [x] I've linted, tested, and commented my code
- [ ] I've updated documentation (if appropriate)


<img width="1740" alt="image" src="https://github.com/user-attachments/assets/62fa310f-f3d3-41ce-a819-a4028498f7f3" />


